### PR TITLE
fix import secp256k1 pem

### DIFF
--- a/ic/identity.py
+++ b/ic/identity.py
@@ -1,4 +1,6 @@
 import hashlib
+
+from ecdsa.curves import Ed25519, SECP256k1
 from .principal import Principal
 from .keys_adapted import SigningKeyApapted
 import ecdsa
@@ -35,7 +37,12 @@ class Identity:
     def from_pem(pem: str):
         key = SigningKeyApapted.from_pem(pem)
         privkey = key.to_string().hex()
-        return Identity(privkey=privkey, type='ed25519')
+        type = "unknown"
+        if key.curve == Ed25519:
+            type = 'ed25519'
+        elif key.curve == SECP256k1:
+            type = 'secp256k1'
+        return Identity(privkey=privkey, type=type)
 
     def to_pem(self):
         pem = self.sk.to_pem(format="pkcs8")


### PR DESCRIPTION
Fix #13.
Pem file export from Plug wallet is secp256k1. Create an identity by `key.curve`.