### PR TITLE
fix record and variant name

### DIFF
--- a/ic/candid.py
+++ b/ic/candid.py
@@ -74,7 +74,7 @@ class TypeTable():
         self._idx = {}
 
     def has(self, obj: ConstructType):
-        return True if obj.name in self._idx else False
+        return obj.name in self._idx
 
     def add(self, obj: ConstructType, buf):
         idx = len(self._typs)
@@ -676,7 +676,8 @@ class RecordClass(ConstructType):
 
     @property
     def name(self) -> str:
-        return "record"
+        fields = ";".join(map(lambda kv: kv[0] + ":" + kv[1].name, self._fields.items()))
+        return "record {{{}}}".format(fields) 
 
     @property
     def id(self) -> int:
@@ -804,8 +805,8 @@ class VariantClass(ConstructType):
 
     @property
     def name(self) -> str:
-        # return 'variant {}'.format(self._fields)
-        return 'variant'
+        fields = ";".join(map(lambda kv: kv[0] + ":" + kv[1].name, self._fields.items()))
+        return 'variant {{{}}}'.format(fields)
 
     @property
     def id(self) -> int:

--- a/ic/candid.py
+++ b/ic/candid.py
@@ -676,7 +676,7 @@ class RecordClass(ConstructType):
 
     @property
     def name(self) -> str:
-        fields = ";".join(map(lambda kv: kv[0] + ":" + kv[1].name, self._fields.items()))
+        fields = ";".join(map(lambda kv: str(kv[0]) + ":" + kv[1].name, self._fields.items()))
         return "record {{{}}}".format(fields) 
 
     @property
@@ -805,7 +805,7 @@ class VariantClass(ConstructType):
 
     @property
     def name(self) -> str:
-        fields = ";".join(map(lambda kv: kv[0] + ":" + kv[1].name, self._fields.items()))
+        fields = ";".join(map(lambda kv: str(kv[0]) + ":" + kv[1].name, self._fields.items()))
         return 'variant {{{}}}'.format(fields)
 
     @property
@@ -859,7 +859,7 @@ class RecClass(ConstructType):
 
     @property
     def name(self) -> str:
-        return labelHash('rec_{}'.format(self._id))
+        return 'rec_{}'.format(self._id)
 
 
     def display(self):

--- a/tests/test_candid.py
+++ b/tests/test_candid.py
@@ -46,7 +46,6 @@ class TestCandid:
         data = bytes.fromhex('4449444c016c02d3e3aa027c868eb7027101002a04f09f92a9')
         res = decode(data)
         assert len(res) == 1
-        assert type(res[0]["type"]) == int
         assert res[0]['value'] == {'_4895187': 42, '_5097222': '💩'}
 
     # def test_tuple_encode(self):


### PR DESCRIPTION
For record and variant, `name` must be unique for different structs to support `buildTypetable` when identifying existing tables.