### PR TITLE
Infinite timeouts make the library hard to use in production

### DIFF
--- a/ic/agent.py
+++ b/ic/agent.py
@@ -7,6 +7,7 @@ from .constants import *
 from .utils import to_request_id
 from .certificate import lookup
 
+DEFAULT_POLL_TIMEOUT_SECS=60.0
 
 def sign_request(req, iden):
     req_id = to_request_id(req)
@@ -214,7 +215,7 @@ class Agent:
         else:
             return status.decode(), cert
 
-    def poll(self, canister_id, req_id, delay=1, timeout=float('inf')):
+    def poll(self, canister_id, req_id, delay=1, timeout=DEFAULT_POLL_TIMEOUT_SECS):
         status = None
         for _ in wait(delay, timeout):
             status, cert = self.request_status_raw(canister_id, req_id)
@@ -232,7 +233,7 @@ class Agent:
         else:
             return status, _
     
-    async def poll_async(self, canister_id, req_id, delay=1, timeout=float('inf')):
+    async def poll_async(self, canister_id, req_id, delay=1, timeout=DEFAULT_POLL_TIMEOUT_SECS):
         status = None
         for _ in wait(delay, timeout):
             status, cert = await self.request_status_raw_async(canister_id, req_id)

--- a/ic/client.py
+++ b/ic/client.py
@@ -2,13 +2,14 @@
 
 import httpx
 
-DEFAULT_TIMEOUT = None
+DEFAULT_TIMEOUT = 120.0
+DEFAULT_TIMEOUT_QUERY = 30.0
 
 class Client:
     def __init__(self, url = "https://ic0.app"):
         self.url = url
 
-    def query(self, canister_id, data, *, timeout = DEFAULT_TIMEOUT):
+    def query(self, canister_id, data, *, timeout = DEFAULT_TIMEOUT_QUERY):
         endpoint = self.url + '/api/v2/canister/' + canister_id + '/query'
         headers = {'Content-Type': 'application/cbor'}
         ret = httpx.post(endpoint, data = data, headers=headers, timeout=timeout)
@@ -20,19 +21,19 @@ class Client:
         ret = httpx.post(endpoint, data = data, headers=headers, timeout=timeout)
         return req_id
 
-    def read_state(self, canister_id, data, *, timeout = DEFAULT_TIMEOUT):
+    def read_state(self, canister_id, data, *, timeout = DEFAULT_TIMEOUT_QUERY):
         endpoint = self.url + '/api/v2/canister/' + canister_id + '/read_state'
         headers = {'Content-Type': 'application/cbor'}
         ret = httpx.post(endpoint, data = data, headers=headers, timeout=timeout)
         return ret.content
 
-    def status(self, *, timeout = DEFAULT_TIMEOUT):
+    def status(self, *, timeout = DEFAULT_TIMEOUT_QUERY):
         endpoint = self.url + '/api/v2/status'
         ret = httpx.get(endpoint, timeout=timeout)
         print('client.status:', ret.text)
         return ret.content
 
-    async def query_async(self, canister_id, data, *, timeout = DEFAULT_TIMEOUT):
+    async def query_async(self, canister_id, data, *, timeout = DEFAULT_TIMEOUT_QUERY):
         async with httpx.AsyncClient(timeout=timeout) as client:
             endpoint = self.url + '/api/v2/canister/' + canister_id + '/query'
             headers = {'Content-Type': 'application/cbor'}
@@ -46,14 +47,14 @@ class Client:
             await client.post(endpoint, data = data, headers=headers)
             return req_id
 
-    async def read_state_async(self, canister_id, data, *, timeout = DEFAULT_TIMEOUT):
+    async def read_state_async(self, canister_id, data, *, timeout = DEFAULT_TIMEOUT_QUERY):
         async with httpx.AsyncClient(timeout=timeout) as client:
             endpoint = self.url + '/api/v2/canister/' + canister_id + '/read_state'
             headers = {'Content-Type': 'application/cbor'}
             ret = await client.post(endpoint, data = data, headers=headers)
             return ret.content
 
-    async def status_async(self, *, timeout = DEFAULT_TIMEOUT):
+    async def status_async(self, *, timeout = DEFAULT_TIMEOUT_QUERY):
         async with httpx.AsyncClient(timeout=timeout) as client:
             endpoint = self.url + '/api/v2/status'
             ret = await client.get(endpoint)


### PR DESCRIPTION
The timeouts I have been setting are somewhat arbitrary and should really be configurable, but I think this is far better than no timeouts.

We use this library for benchmarking, and if requests get stuck "forever" many of those benchmarks never complete and stop making progress.

Ultimately, the user should retry if things time out, which is difficult if requests don't time out in this library.