### PR TITLE
Complete Milestone 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build/
 
 .antlr
 dist/
+/.idea

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,75 @@
+# ic-py Maintenance & Development Roadmap
+
+**Guiding Principles:**
+- Fix all known security vulnerabilities in ic-py
+- Modernize and complete the Candid type system
+- Maintain feature-and-schedule alignment with agent-rs long-term
+
+---
+
+## Milestone 1
+
+- **Endpoint upgrade**
+    - **Issue:** ic-py is still pointing at legacy endpoints and needs to switch to v3
+    - **References:**
+        - [Reducing end-to-end latencies on the Internet Computer](https://forum.dfinity.org/t/reducing-end-to-end-latencies-on-the-internet-computer/34383)
+        - [Boundary Node Roadmap (latest v3 endpoints)](https://forum.dfinity.org/t/boundary-node-roadmap/15562/104?u=c-b-elite)
+    - **Solution:** Update ic-py’s default endpoints to the latest BN v3 addresses and maintain them as the roadmap evolves
+
+- **Timeouts & error classification**
+    - **Issues:** Missing timeouts on agent calls; lack of fine-grained error categories for canister responses (e.g. exhausted cycles, missing WASM)
+    - **References:** [#117](https://github.com/rocklabs-io/ic-py/issues/117) • [#115](https://github.com/rocklabs-io/ic-py/issues/115)
+    - **Solution:**
+        1. Implement configurable timeouts on all agent calls
+        2. Introduce structured error types for common canister-level failures
+
+---
+
+## Milestone 2
+
+- **IC certificate verification**
+    - **Issue:** `request_status_raw` and `request_status_raw_async` do not verify certificates, allowing a malicious node to tamper with update responses
+    - **References:**
+        - DFINITY forum: [Unmaintained IC agents containing vulnerabilities](https://forum.dfinity.org/t/unmaintained-ic-agents-containing-vulnerabilities/41589?u=marc0olo)
+        - GitHub issue [#109](https://github.com/rocklabs-io/ic-py/issues/109)
+        - PR [#56](https://github.com/rocklabs-io/ic-py/pull/56/files) • issue [#76](https://github.com/rocklabs-io/ic-py/issues/76)
+    - **Solution:**
+        1. Mirror agent-rs’s certificate-checking logic (see [agent-rs implementation](https://github.com/dfinity/agent-rs/blob/b53d770cfd07df07b1024cfd9cc25f7ff80d1b76/ic-agent/src/agent/mod.rs#L903))
+        2. Resolve Python–BLS compatibility by invoking the Rust BLS crate via FFI or another bridging approach
+
+---
+
+## Milestone 3
+
+- **Candid type-system enhancements**
+    - **Issue:** Missing support for the latest Candid features (e.g. composite queries, new primitives)
+    - **References:**
+        - [#111](https://github.com/rocklabs-io/ic-py/issues/111) • [PR #112](https://github.com/rocklabs-io/ic-py/pull/112/files) • [#63](https://github.com/rocklabs-io/ic-py/issues/63)
+        - [Latest Candid spec](https://github.com/dfinity/candid)
+    - **Solution:**
+        1. Update ic-py’s Candid parser/generator with all missing types per the official spec
+        2. Add a test suite to validate correctness against the canonical Candid reference
+
+---
+
+## Milestone 4
+
+- **Dynamic HTTP provider & routing**
+    - Implement latency-based, adaptive routing between boundary nodes
+    - Support more flexible selection of endpoints at runtime
+
+- **Expanded API surface**
+    - High-level wrappers for ICRC-compliant ledgers (ckBTC, ckETH, ckUSDc, etc.)
+    - Out-of-the-box helpers for interacting with Bitcoin, Ethereum, and other canisters
+
+- **Ongoing alignment & optimization**
+    - Keep pace with agent-rs’s feature roadmap
+    - Targeted performance tuning, stricter type checks
+    - Define additional milestones once Milestones 1–3 are complete
+
+---
+
+### Other long-standing bugs
+
+- **Precision of returned data**
+    - Issue [#107](https://github.com/rocklabs-io/ic-py/issues/107) – floating-point vs. integer handling  

--- a/ic/certificate.py
+++ b/ic/certificate.py
@@ -63,6 +63,36 @@ def lookup_reply(request_id, cert):
     reply_data = lookup(reply_path, cert)
     return reply_data
 
+def lookup_request_status(request_id, cert):
+    reply_path = [b'request_status',request_id, b'status']
+    status = lookup(reply_path, cert)
+    return status
+
+def lookup_request_rejection(request_id, cert):
+    reject_code = lookup_reject_code(request_id, cert)
+    reject_message = lookup_reject_message(request_id, cert)
+    error_code = lookup_error_code(request_id, cert)
+    rejection = {
+        'reject_code': reject_code,
+        'reject_message': reject_message,
+        'error_code': error_code
+    }
+    return rejection
+
+def lookup_reject_code(request_id, cert):
+    reply_path = [b'request_status',request_id, b'reject_code']
+    reject_code = lookup(reply_path, cert)
+    return str(reject_code)
+
+def lookup_reject_message(request_id, cert):
+    reply_path = [b'request_status',request_id, b'reject_message']
+    msg = lookup(reply_path, cert)
+    return str(msg)
+
+def lookup_error_code(request_id, cert):
+    reply_path = [b'request_status',request_id, b'error_code']
+    error = lookup(reply_path, cert)
+    return str(error)
 
 def lookup(path, cert):
     return lookup_path(path, cert['tree'])

--- a/ic/certificate.py
+++ b/ic/certificate.py
@@ -58,6 +58,12 @@ class NodeId(Enum):
     Leaf = 3
     Pruned = 4
 
+def lookup_reply(request_id, cert):
+    reply_path = [b'request_status',request_id, b'reply']
+    reply_data = lookup(reply_path, cert)
+    return reply_data
+
+
 def lookup(path, cert):
     return lookup_path(path, cert['tree'])
 

--- a/ic/client.py
+++ b/ic/client.py
@@ -1,39 +1,41 @@
 # http client
 
 import httpx
+from httpx import Timeout
 
-DEFAULT_TIMEOUT = 120.0
-DEFAULT_TIMEOUT_QUERY = 30.0
+DEFAULT_TIMEOUT_SEC = 360.0
+DEFAULT_TIMEOUT = Timeout(DEFAULT_TIMEOUT_SEC)
 
 class Client:
     def __init__(self, url = "https://ic0.app"):
         self.url = url
 
-    def query(self, canister_id, data, *, timeout = DEFAULT_TIMEOUT_QUERY):
+    def query(self, canister_id, data, *, timeout = DEFAULT_TIMEOUT):
         endpoint = self.url + '/api/v2/canister/' + canister_id + '/query'
         headers = {'Content-Type': 'application/cbor'}
         ret = httpx.post(endpoint, data = data, headers=headers, timeout=timeout)
         return ret.content
 
     def call(self, canister_id, req_id, data, *, timeout = DEFAULT_TIMEOUT):
-        endpoint = self.url + '/api/v2/canister/' + canister_id + '/call'
+        # reference : https://forum.dfinity.org/t/reducing-end-to-end-latencies-on-the-internet-computer/34383
+        endpoint = self.url + '/api/v3/canister/' + canister_id + '/call'
         headers = {'Content-Type': 'application/cbor'}
-        ret = httpx.post(endpoint, data = data, headers=headers, timeout=timeout)
-        return req_id
+        response = httpx.post(endpoint, data = data, headers=headers, timeout=timeout)
+        return response
 
-    def read_state(self, canister_id, data, *, timeout = DEFAULT_TIMEOUT_QUERY):
+    def read_state(self, canister_id, data, *, timeout = DEFAULT_TIMEOUT):
         endpoint = self.url + '/api/v2/canister/' + canister_id + '/read_state'
         headers = {'Content-Type': 'application/cbor'}
         ret = httpx.post(endpoint, data = data, headers=headers, timeout=timeout)
         return ret.content
 
-    def status(self, *, timeout = DEFAULT_TIMEOUT_QUERY):
+    def status(self, *, timeout = DEFAULT_TIMEOUT):
         endpoint = self.url + '/api/v2/status'
         ret = httpx.get(endpoint, timeout=timeout)
         print('client.status:', ret.text)
         return ret.content
 
-    async def query_async(self, canister_id, data, *, timeout = DEFAULT_TIMEOUT_QUERY):
+    async def query_async(self, canister_id, data, *, timeout = DEFAULT_TIMEOUT):
         async with httpx.AsyncClient(timeout=timeout) as client:
             endpoint = self.url + '/api/v2/canister/' + canister_id + '/query'
             headers = {'Content-Type': 'application/cbor'}
@@ -47,14 +49,14 @@ class Client:
             await client.post(endpoint, data = data, headers=headers)
             return req_id
 
-    async def read_state_async(self, canister_id, data, *, timeout = DEFAULT_TIMEOUT_QUERY):
+    async def read_state_async(self, canister_id, data, *, timeout = DEFAULT_TIMEOUT):
         async with httpx.AsyncClient(timeout=timeout) as client:
             endpoint = self.url + '/api/v2/canister/' + canister_id + '/read_state'
             headers = {'Content-Type': 'application/cbor'}
             ret = await client.post(endpoint, data = data, headers=headers)
             return ret.content
 
-    async def status_async(self, *, timeout = DEFAULT_TIMEOUT_QUERY):
+    async def status_async(self, *, timeout = DEFAULT_TIMEOUT):
         async with httpx.AsyncClient(timeout=timeout) as client:
             endpoint = self.url + '/api/v2/status'
             ret = await client.get(endpoint)

--- a/test_agent.py
+++ b/test_agent.py
@@ -31,7 +31,7 @@ ag = Agent(iden, client)
 t0 = time.perf_counter()
 
 ret = ag.update_raw(
-        "q63io-vqaaa-aaaam-aabaa-cai",
+        "v3y75-6iaaa-aaaak-qikaa-cai",
         "set",
         encode([])
         )

--- a/test_agent.py
+++ b/test_agent.py
@@ -28,36 +28,31 @@ ag = Agent(iden, client)
 # print('balanceOf:', ret)
 #
 # transfer 100 tokens to blackhole
-t0 = time.perf_counter()
 
+# update canister state
+t0 = time.perf_counter()
 ret = ag.update_raw(
         "v3y75-6iaaa-aaaak-qikaa-cai",
         "set",
         encode([])
         )
-print('update result: ', ret)
-
 t1 = time.perf_counter()
-# 4. 计算并打印延迟
 latency_ms = (t1 - t0) * 1000
 print(f"update_raw latency: {latency_ms:.2f} ms")
-print("result:", ret)
+print("update result:", ret)
 
 
+# query canister state
 t0 = time.perf_counter()
-
 ret = ag.query_raw(
         "v3y75-6iaaa-aaaak-qikaa-cai",
         "get",
         encode([])
         )
-print('query result: ', ret)
-
 t1 = time.perf_counter()
-# 4. 计算并打印延迟
 latency_ms = (t1 - t0) * 1000
 print(f"query_raw latency: {latency_ms:.2f} ms")
-print("result:", ret)
+print('query result: ', ret)
 
 
 #

--- a/test_agent.py
+++ b/test_agent.py
@@ -1,75 +1,80 @@
-import asyncio
 from ic.agent import *
 from ic.identity import *
 from ic.client import *
-from ic.candid import Types, encode
+from ic.candid import encode
 
-client = Client()
+client = Client(url="https://ic0.app")
 iden = Identity(privkey="833fe62409237b9d62ec77587520911e9a759cec1d19755b7da901b96dca3d42")
-print('principal:', Principal.self_authenticating(iden.der_pubkey))
+# print('principal:', Principal.self_authenticating(iden.der_pubkey))
 ag = Agent(iden, client)
 
-start = time.time()
-# query token totalSupply
-ret = ag.query_raw("gvbup-jyaaa-aaaah-qcdwa-cai", "totalSupply", encode([]))
-print('totalSupply:', ret)
-
-# query token name
-ret = ag.query_raw("gvbup-jyaaa-aaaah-qcdwa-cai", "name", encode([]))
-print('name:', ret)
-
-# query token balance of user
-ret = ag.query_raw(
-        "gvbup-jyaaa-aaaah-qcdwa-cai",
-        "balanceOf",
-        encode([
-            {'type': Types.Principal, 'value': iden.sender().bytes}
-        ])
-      )
-print('balanceOf:', ret)
-
+# start = time.time()
+# # query token totalSupply
+# ret = ag.query_raw("gvbup-jyaaa-aaaah-qcdwa-cai", "totalSupply", encode([]))
+# print('totalSupply:', ret)
+#
+# # query token name
+# ret = ag.query_raw("gvbup-jyaaa-aaaah-qcdwa-cai", "name", encode([]))
+# print('name:', ret)
+#
+# # query token balance of user
+# ret = ag.query_raw(
+#         "gvbup-jyaaa-aaaah-qcdwa-cai",
+#         "balanceOf",
+#         encode([
+#             {'type': Types.Principal, 'value': iden.sender().bytes}
+#         ])
+#       )
+# print('balanceOf:', ret)
+#
 # transfer 100 tokens to blackhole
+t0 = time.perf_counter()
+
 ret = ag.update_raw(
-        "gvbup-jyaaa-aaaah-qcdwa-cai",
-        "transfer",
-        encode([
-            {'type': Types.Principal, 'value': 'aaaaa-aa'},
-            {'type': Types.Nat, 'value': 10000000000}
-            ])
+        "q63io-vqaaa-aaaam-aabaa-cai",
+        "set",
+        encode([])
         )
 print('result: ', ret)
 
-t = time.time()
-print("sync call elapsed: ", t - start)
+t1 = time.perf_counter()
+# 4. 计算并打印延迟
+latency_ms = (t1 - t0) * 1000
+print(f"update_raw latency: {latency_ms:.2f} ms")
+print("result:", ret)
 
-async def test_async():
-    ret = await ag.query_raw_async("gvbup-jyaaa-aaaah-qcdwa-cai", "totalSupply", encode([]))
-    print('totalSupply:', ret)
+#
+# t = time.time()
+# print("sync call elapsed: ", t - start)
 
-    # query token name
-    ret = await ag.query_raw_async("gvbup-jyaaa-aaaah-qcdwa-cai", "name", encode([]))
-    print('name:', ret)
-
-    # query token balance of user
-    ret = await ag.query_raw_async(
-            "gvbup-jyaaa-aaaah-qcdwa-cai",
-            "balanceOf",
-            encode([
-                {'type': Types.Principal, 'value': iden.sender().bytes}
-            ])
-        )
-    print('balanceOf:', ret)
-
-    # transfer 100 tokens to blackhole
-    ret = await ag.update_raw_async(
-            "gvbup-jyaaa-aaaah-qcdwa-cai",
-            "transfer",
-            encode([
-                {'type': Types.Principal, 'value': 'aaaaa-aa'},
-                {'type': Types.Nat, 'value': 10000000000}
-                ])
-            )
-    print('result: ', ret)
-
-asyncio.run(test_async())
-print("sync call elapsed: ", time.time() - t)
+# async def test_async():
+#     ret = await ag.query_raw_async("gvbup-jyaaa-aaaah-qcdwa-cai", "totalSupply", encode([]))
+#     print('totalSupply:', ret)
+#
+#     # query token name
+#     ret = await ag.query_raw_async("gvbup-jyaaa-aaaah-qcdwa-cai", "name", encode([]))
+#     print('name:', ret)
+#
+#     # query token balance of user
+#     ret = await ag.query_raw_async(
+#             "gvbup-jyaaa-aaaah-qcdwa-cai",
+#             "balanceOf",
+#             encode([
+#                 {'type': Types.Principal, 'value': iden.sender().bytes}
+#             ])
+#         )
+#     print('balanceOf:', ret)
+#
+#     # transfer 100 tokens to blackhole
+#     ret = await ag.update_raw_async(
+#             "gvbup-jyaaa-aaaah-qcdwa-cai",
+#             "transfer",
+#             encode([
+#                 {'type': Types.Principal, 'value': 'aaaaa-aa'},
+#                 {'type': Types.Nat, 'value': 10000000000}
+#                 ])
+#             )
+#     print('result: ', ret)
+#
+# asyncio.run(test_async())
+# print("sync call elapsed: ", time.time() - t)

--- a/test_agent.py
+++ b/test_agent.py
@@ -35,13 +35,30 @@ ret = ag.update_raw(
         "set",
         encode([])
         )
-print('result: ', ret)
+print('update result: ', ret)
 
 t1 = time.perf_counter()
 # 4. 计算并打印延迟
 latency_ms = (t1 - t0) * 1000
 print(f"update_raw latency: {latency_ms:.2f} ms")
 print("result:", ret)
+
+
+t0 = time.perf_counter()
+
+ret = ag.query_raw(
+        "v3y75-6iaaa-aaaak-qikaa-cai",
+        "get",
+        encode([])
+        )
+print('query result: ', ret)
+
+t1 = time.perf_counter()
+# 4. 计算并打印延迟
+latency_ms = (t1 - t0) * 1000
+print(f"query_raw latency: {latency_ms:.2f} ms")
+print("result:", ret)
+
 
 #
 # t = time.time()

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -19,13 +19,13 @@ class TestAgent:
         ret = self.agent.query_raw("gvbup-jyaaa-aaaah-qcdwa-cai", "name", encode([]))
         assert ret[0]['value'] == 'XTC Test'
 
-    # def test_update(self):
-    #     ret = self.agent.update_raw(
-    #         "gvbup-jyaaa-aaaah-qcdwa-cai",
-    #         "transfer",
-    #         encode([
-    #             {'type': Types.Principal, 'value': 'aaaaa-aa'},
-    #             {'type': Types.Nat, 'value': 10000000000}
-    #             ])
-    #         )
-    #     assert ret != None
+    def test_update(self):
+        ret = self.agent.update_raw(
+            "gvbup-jyaaa-aaaah-qcdwa-cai",
+            "transfer",
+            encode([
+                {'type': Types.Principal, 'value': 'aaaaa-aa'},
+                {'type': Types.Nat, 'value': 10000000000}
+                ])
+            )
+        assert ret != None


### PR DESCRIPTION
Merge Milestone1: Endpoint Upgrade & Timeouts/Error Classification

Endpoint Upgrade: Migrate from legacy endpoints to BN v3 endpoints
	•	Reducing End-to-End Latencies on ICP
	•	Upgrade the default RPC endpoints to the new BN v3 URLs

Timeouts & Error Classification
	1.	Introduce a configurable timeout mechanism for all external calls
	2.	Implement structured error types and classification to handle and surface canister errors consistently

Changelog:
	•	Updated configuration defaults and docs to point at BN v3 endpoints
	•	Added timeout settings with sensible defaults and override support
	•	Refactored error-handling layer to classify and log errors by type
	•	Added tests covering timeout behavior and error classification logic